### PR TITLE
Bilevel planning fix

### DIFF
--- a/src/geom2drobotenvs/envs/base_env.py
+++ b/src/geom2drobotenvs/envs/base_env.py
@@ -175,11 +175,11 @@ class Geom2DRobotEnv(gym.Env):
 
         # Check for collisions, and only update the state if none exist.
         moving_objects = {robot} | {o for o, _ in suctioned_objs}
-        obstacles = set(state) - moving_objects
         full_state = state.copy()
         if self._initial_constant_state is not None:
             # Merge the initial constant state with the current state.
             full_state.data.update(self._initial_constant_state.data)
+        obstacles = set(full_state) - moving_objects
         if not state_has_collision(
             full_state, moving_objects, obstacles, self._static_object_body_cache
         ):

--- a/src/geom2drobotenvs/envs/base_env.py
+++ b/src/geom2drobotenvs/envs/base_env.py
@@ -100,8 +100,8 @@ class Geom2DRobotEnv(gym.Env):
 
     def _get_obs(self) -> ObjectCentricState:
         assert self._current_state is not None, "Need to call reset()"
-        # NOTE: Based on the discussion, we comit to providing
-        # only the changable objects in the state.
+        # NOTE: Based on the discussion, we commit to providing
+        # only the changeable objects in the state.
         # A learning-based algorithm has no access to the
         # initial constant state, as the algorithm should learn
         # to handle them if they affect decision making.


### PR DESCRIPTION
Based on our discussion [here](https://github.com/tomsilver/prbench-bilevel-planning/pull/6#discussion_r2264960069), we commit to providing only the changeable object states in `get_obs` function. A planner model can still access the static objects via an interface provided by the environment instance.